### PR TITLE
Add error class for rendering error in templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ Thumbs.db
 
 
 # End of https://www.toptal.com/developers/gitignore/api/django
+**/.idea/

--- a/project/TAScheduler/views.py
+++ b/project/TAScheduler/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render
 from django.views import View
 
 from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.errors import PageError, LoginError
 
 # Create your views here.
 class Index(View):
@@ -17,7 +18,9 @@ class Index(View):
 
 class Login(View):
     def get(self, request):
-        return render(request, 'pages/login.html')
+        return render(request, 'pages/login.html', {
+            'error': LoginError(PageError('This is a password error'), LoginError.Place.USERNAME)
+        })
 
     def post(self, request):
         print('User Tried to log in')

--- a/project/TAScheduler/viewsupport/errors.py
+++ b/project/TAScheduler/viewsupport/errors.py
@@ -1,0 +1,41 @@
+from typing import Optional
+
+class PageError:
+    """
+    Represents an error which may or may not have a headline, and which should be rendered with the
+    `partials/inline_error.html` partial.
+    """
+
+    def __init__(self, body: str, headline: Optional[str] = None):
+        """
+        Create a new basic error with or without a headline value
+        """
+        self._body = body
+        self._headline = headline
+
+    def has_headline(self) -> bool:
+        """
+        Returns true if the error has a headline value, used by template
+        to render as a error panel instead of alert.
+        :return:
+        """
+        return self._headline is not None
+
+    def headline(self) -> str:
+        """
+        Raises TypeError in the case that this error has no headline,
+        use has_headline() to check beforehand.
+        """
+
+        if self._headline is None:
+            raise TypeError('Tried to get headline from error without one')
+
+        return self._headline
+
+    def body(self) -> str:
+        """
+        Returns the body text of this error
+        :return:
+        """
+
+        return self._body

--- a/project/TAScheduler/viewsupport/errors.py
+++ b/project/TAScheduler/viewsupport/errors.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from typing import Optional, Union
+from enum import Enum
 
 class PageError:
     """
@@ -39,3 +40,35 @@ class PageError:
         """
 
         return self._body
+
+
+class LoginError:
+    """
+    Represents an error to be used on the login page,
+    placed with the username or password field depending on the variant
+    """
+
+    class Place(Enum):
+        USERNAME = 0
+        PASSWORD = 1
+
+    def __init__(self, error_text: Union[PageError, str], place: Place):
+        self._place = place
+        if type(error_text) is PageError:
+            self._error = error_text
+        elif type(error_text) is str:
+            self._error = PageError(error_text)
+        else:
+            raise TypeError('LoginError must be of type PageError or str')
+
+    def error(self) -> PageError:
+        """Gets the inner error of this instance of LoginError"""
+        return self._error
+
+    def place_username(self):
+        """Returns true iff this login error is associated with the login field"""
+        return self._place == LoginError.Place.USERNAME
+
+    def place_password(self):
+        """Returns true iff this login error is associated with the password field"""
+        return self._place == LoginError.Place.PASSWORD

--- a/project/TAScheduler/viewsupport/test_errors.py
+++ b/project/TAScheduler/viewsupport/test_errors.py
@@ -1,0 +1,34 @@
+import unittest
+from TAScheduler.viewsupport.errors import PageError
+
+class TestBasicErrors(unittest.TestCase):
+
+    def setUp(self):
+        self.error = PageError('This is the body of the error')
+
+    def test_creates(self):
+        self.assertEqual(self.error.body(), 'This is the body of the error', 'Does not return correct body')
+
+    def test_no_headline(self):
+        self.assertEqual(self.error.has_headline(), False, 'Does not correctly indicate no error')
+
+    def test_get_headline_raises(self):
+        with self.assertRaises(TypeError, 'Did not raise correct exception in case where tried to access nonexistant headline'):
+            self.error.headline()
+
+class TestHeadlineErrors(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.error = PageError('This is the body of the error', 'Headline')
+
+    def test_creates(self):
+        self.assertEqual(self.error.body(), 'This is the body of the error', 'Did not return correct body')
+
+    def test_has_headline(self):
+        self.assertTrue(self.error.has_headline(), 'Did not indicate existence of headline correctly')
+
+    def test_returns_headline(self):
+        self.assertEqual(self.error.headline(), 'Headline', 'Did not return correct headline')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/project/TAScheduler/viewsupport/test_errors.py
+++ b/project/TAScheduler/viewsupport/test_errors.py
@@ -13,7 +13,7 @@ class TestBasicErrors(unittest.TestCase):
         self.assertEqual(self.error.has_headline(), False, 'Does not correctly indicate no error')
 
     def test_get_headline_raises(self):
-        with self.assertRaises(TypeError, 'Did not raise correct exception in case where tried to access nonexistant headline'):
+        with self.assertRaises(TypeError, msg='Did not raise correct exception in case where tried to access nonexistant headline'):
             self.error.headline()
 
 class TestHeadlineErrors(unittest.TestCase):

--- a/project/templates/pages/login.html
+++ b/project/templates/pages/login.html
@@ -17,11 +17,17 @@
                     <input type="email" name="username" class="form-control"/>
                     <div class="input-group-addon">@uwm.edu</div>
                 </div>
+                {% if error is not None and error.place_username %}
+                    {% include 'partials/inline_error.html' with error=error.error only %}
+                {% endif %}
             </div>
 
             <div class="form-group">
                 <label for="password">password</label>
                 <input type="password" name="password" class="form-control" />
+                {% if error is not None and error.place_password %}
+                    {% include 'partials/inline_error.html' with error=error.error only %}
+                {% endif %}
             </div>
 
             <div class="form-group">

--- a/project/templates/pages/login.html
+++ b/project/templates/pages/login.html
@@ -6,19 +6,22 @@
     <div class="col-xs-12 col-sm-4">
 
         <!-- Login Form with Home button -->
-        <form class="form-horizontal" method="post">
+        <form class="form" method="post">
             {% csrf_token %}
 
             <h1>Log in</h1>
 
             <div class="form-group">
                 <label for="username">username</label>
-                <input type="email" name="username" />
+                <div class="input-group">
+                    <input type="email" name="username" class="form-control"/>
+                    <div class="input-group-addon">@uwm.edu</div>
+                </div>
             </div>
 
             <div class="form-group">
                 <label for="password">password</label>
-                <input type="password" name="password" />
+                <input type="password" name="password" class="form-control" />
             </div>
 
             <div class="form-group">

--- a/project/templates/partials/inline_error.html
+++ b/project/templates/partials/inline_error.html
@@ -4,7 +4,7 @@ Render a single error, see TAScheduler.viewsupport.errors for the construction o
 
 {% if error.has_headline %}
 
-<div class="panel panel-danger">
+<div class="panel panel-danger form-control" style="margin-top: 1em">
     <div class="panel-heading">
         {{ error.headline }}
     </div>
@@ -15,8 +15,8 @@ Render a single error, see TAScheduler.viewsupport.errors for the construction o
 
 {% else %}
 
-<div class="alert alert-danger">
-    <em>{{ error.body }}</em>
+<div class="alert alert-danger" style="margin-top: 1em">
+    {{ error.body }}
 </div>
 
 {% endif %}

--- a/project/templates/partials/inline_error.html
+++ b/project/templates/partials/inline_error.html
@@ -1,0 +1,22 @@
+{% comment %}
+Render a single error, see TAScheduler.viewsupport.errors for the construction of the error.
+{% endcomment %}
+
+{% if error.has_headline %}
+
+<div class="panel panel-danger">
+    <div class="panel-heading">
+        {{ error.headline }}
+    </div>
+    <div class="panel-body">
+        {{ error.body }}
+    </div>
+</div>
+
+{% else %}
+
+<div class="alert alert-danger">
+    <em>{{ error.body }}</em>
+</div>
+
+{% endif %}

--- a/project/templates/partials/sidebar.html
+++ b/project/templates/partials/sidebar.html
@@ -21,15 +21,17 @@ See documentation for the TAScheduler.viewsupport.navbar for more information
     {% for item in navbar_items %}
         {% if not item.get_enabled %}
             <li class="active disabled">
-                {% else %}
+        {% else %}
             <li>
         {% endif %}
+
         <a href="{{ item.get_url }}">
             {% if item.has_icons %}
                 <span class="{{ item.get_icon_classes }}" style="padding-right: 0.75em"></span>
             {% endif %}
             {{ item.get_name }}
         </a>
+
     </li>
     {% endfor %}
     </ul>


### PR DESCRIPTION
Adds a basic partial template and python class for rendering errors inline in templates. Uses these to add two places in login form where errors can be rendered: below username for no such user errors, and below password for incorrect password errors. 