### PR TITLE
Acceptance Tests for Lab views

### DIFF
--- a/TAScheduler/acceptance_tests/acceptance_base.py
+++ b/TAScheduler/acceptance_tests/acceptance_base.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from typing import TypeVar, Generic, Optional
+from TAScheduler.viewsupport.message import Message, MessageQueue
+
+E = TypeVar('E')
+
+class TASAcceptanceTestCase(Generic[E], TestCase):
+
+    def assertContainsMessage(self, resp, has: Message, msg: Optional[str] = None):
+        """
+        Assert that the session contains a message, must be called before redirects are
+        evaluated as most pages drain the message queue.
+        """
+        if msg is None:
+            msg = f'Context did not contain message {has}'
+
+        self.assertTrue(has in MessageQueue.get(resp.client.session), msg=msg)
+
+    def assertContextVar(self, resp, var_name: str) -> object:
+        ret = resp.context.get(var_name)
+
+        self.assertIsNotNone(ret, msg=f'Context did not contain any variable with the name {var_name}')
+        return ret
+
+    def assertContextError(self, resp) -> E:
+        """
+        Assert that the render context contains an error object of the type T and return it.
+        """
+        error = self.assertContextVar(resp, 'error')
+
+        self.assertTrue(type(error) is E, msg=f'error context variable exists but was not of type {type(E)}')
+
+        return error

--- a/TAScheduler/acceptance_tests/labs/test_create.py
+++ b/TAScheduler/acceptance_tests/labs/test_create.py
@@ -1,6 +1,11 @@
+from django.test import Client
+from django.shortcuts import reverse
+
 from TAScheduler.acceptance_tests.acceptance_base import TASAcceptanceTestCase
 from TAScheduler.viewsupport.errors import LabError
-from django.test import Client
+from TAScheduler.viewsupport.message import Message, MessageQueue
+
+from TAScheduler.models import User, UserType, Course, CourseSection, LabSection
 
 
 class LabsCreate(TASAcceptanceTestCase[LabError]):
@@ -9,27 +14,156 @@ class LabsCreate(TASAcceptanceTestCase[LabError]):
         self.client = Client()
         self.session = self.client.session
 
+        # Add users
+        self.admin_user = User.objects.create(
+            univ_id='josiahth',
+            password='password',
+            type=UserType.ADMIN,
+            tmp_password=False
+        )
+
+        self.ta_user = User.objects.create(
+            univ_id='nleverence',
+            password='password',
+            type=UserType.TA,
+            tmp_password=False
+        )
+
+        self.prof_user = User.objects.create(
+            univ_id='rock',
+            password='password',
+            type=UserType.PROF,
+            tmp_password=False
+        )
+
+        # Add prerequisite objects
+        self.course = Course.objects.create(
+            course_code='361',
+            course_name='Software Engineering',
+            admin_id=self.admin_user,
+        )
+
+        self.section = CourseSection.objects.create(
+            course_section_code='201',
+            course_id=self.course,
+        )
+
+        # Set current user
+        self.session['user_id'] = self.admin_user.user_id
+        self.session.save()
+
     def test_create_without_days_times(self):
-        pass
+        resp = self.client.post(reverse('labs-create'), {
+            'lab_code': '901',
+            'section_id': self.section.course_section_id,
+        })
+
+        labs = list(LabSection.objects.all())[0]
+
+        self.assertEqual('901', labs.lab_section_code, 'Did not save lab section code to database')
+        self.assertEqual(self.section, labs.course_section_id, 'Did not associate correct course section with new lab')
+
+        self.assertRedirects(resp, reverse('labs-view', args=[labs.lab_section_id]))
 
     def test_create_full(self):
-        pass
+        resp = self.client.post(reverse('labs-create'), {
+            'lab_code': '901',
+            'section_id': self.section.course_section_id,
+            'lab_days': ['M', 'W', 'F'],
+            'lab_time': '2-4',
+        })
+
+        lab = list(LabSection.objects.all())[0]
+
+        for day in 'MWF':
+            self.assertTrue(day in lab.lab_days, f'Day {day} not saved to lab')
+
+        self.assertEqual('2-4', lab.lab_time, 'Did not save correct time to database')
+
+        self.assertRedirects(resp, reverse('labs-view', args=[labs.lab_section_id]))
 
     def test_professor_rejected(self):
-        pass
+        self.session['user_id'] = self.prof_user.user_id
+        self.session.save()
+
+        resp = self.client.post(reverse('labs-create'), {
+            'lab_code': '901',
+            'section_id': self.section.course_section_id,
+        })
+
+        self.assertContainsMessage(resp, Message(
+            'You do not have permission to create new lab sections',
+            Message.Type.ERROR,
+        ))
+
+        self.assertRedirects(resp, reverse('labs-directory'))
 
     def test_ta_redirects(self):
-        pass
+        self.session['user_id'] = self.ta_user.user_id
+        self.session.save()
+
+        resp = self.client.post(reverse('labs-create'), {
+            'lab_code': '901',
+            'section_id': self.section.course_section_id,
+        })
+
+        self.assertContainsMessage(resp, Message(
+            'You do not have permission to create new lab sections',
+            Message.Type.ERROR,
+        ))
+
+        self.assertRedirects(resp, reverse('labs-directory'))
 
     def test_rejects_missing_code(self):
-        pass
+        resp = self.client.post(reverse('labs-create'), {
+            # 'lab_code': '901',
+            'section_id': self.section.course_section_id,
+        })
+
+        error = self.assertContextError(resp)
+
+        self.assertEqual(LabError.Place.CODE, error.place(), 'Did not associate error with correct field')
+        self.assertEqual('You must provide a 3 digit course code', error.error(), 'Did not return correct message')
 
     def test_rejects_non_digit_code(self):
-        pass
+        resp = self.client.post(reverse('labs-create'), {
+            'lab_code': 'abc',
+            'section_id': self.section.course_section_id,
+        })
+
+        error = self.assertContextError(resp)
+
+        self.assertEqual(LabError.Place.CODE, error.place(), 'Did not associate error with correct field')
+        self.assertEqual('You must provide a 3 digit course code', error.error(), 'Did not return correct message')
 
     def test_rejects_mislengthed_code(self):
-        # Test that code lengths must be 3
-        pass
+        resp = self.client.post(reverse('labs-create'), {
+            'lab_code': '90103',
+            'section_id': self.section.course_section_id,
+        })
+
+        error = self.assertContextError(resp)
+
+        self.assertEqual(LabError.Place.CODE, error.place(), 'Did not associate error with correct field')
+        self.assertEqual('You must provide a 3 digit course code', error.error(), 'Did not return correct message')
+
+        resp = self.client.post(reverse('labs-create'), {
+            'lab_code': '9',
+            'section_id': self.section.course_section_id,
+        })
+
+        error = self.assertContextError(resp)
+
+        self.assertEqual(LabError.Place.CODE, error.place(), 'Did not associate error with correct field')
+        self.assertEqual('You must provide a 3 digit course code', error.error(), 'Did not return correct message')
 
     def test_rejects_missing_section(self):
-        pass
+        resp = self.client.post(reverse('labs-create'), {
+            'lab_code': '901',
+            # 'section_id': self.section.course_section_id,
+        })
+
+        error = self.assertContextError(resp)
+
+        self.assertEqual(LabError.Place.SECTION, error.place(), 'Did not associate error with correct field')
+        self.assertEqual('You must pick a section for this lab', error.error(), 'Did not return correct message')

--- a/TAScheduler/acceptance_tests/labs/test_create.py
+++ b/TAScheduler/acceptance_tests/labs/test_create.py
@@ -1,10 +1,35 @@
 from TAScheduler.acceptance_tests.acceptance_base import TASAcceptanceTestCase
-from TAScheduler.viewsupport.errors import TAError
+from TAScheduler.viewsupport.errors import LabError
 from django.test import Client
 
 
-class LabsCreate(TASAcceptanceTestCase[TAError]):
+class LabsCreate(TASAcceptanceTestCase[LabError]):
 
     def setUp(self):
         self.client = Client()
         self.session = self.client.session
+
+    def test_create_without_days_times(self):
+        pass
+
+    def test_create_full(self):
+        pass
+
+    def test_professor_rejected(self):
+        pass
+
+    def test_ta_redirects(self):
+        pass
+
+    def test_rejects_missing_code(self):
+        pass
+
+    def test_rejects_non_digit_code(self):
+        pass
+
+    def test_rejects_mislengthed_code(self):
+        # Test that code lengths must be 3
+        pass
+
+    def test_rejects_missing_section(self):
+        pass

--- a/TAScheduler/acceptance_tests/labs/test_create.py
+++ b/TAScheduler/acceptance_tests/labs/test_create.py
@@ -1,0 +1,10 @@
+from TAScheduler.acceptance_tests.acceptance_base import TASAcceptanceTestCase
+from TAScheduler.viewsupport.errors import TAError
+from django.test import Client
+
+
+class LabsCreate(TASAcceptanceTestCase[TAError]):
+
+    def setUp(self):
+        self.client = Client()
+        self.session = self.client.session

--- a/TAScheduler/acceptance_tests/labs/test_delete.py
+++ b/TAScheduler/acceptance_tests/labs/test_delete.py
@@ -1,6 +1,13 @@
+from django.test import Client
+from django.shortcuts import reverse
+
+from typing import List
+
 from TAScheduler.acceptance_tests.acceptance_base import TASAcceptanceTestCase
 from TAScheduler.viewsupport.errors import LabError
-from django.test import Client
+from TAScheduler.viewsupport.message import Message, MessageQueue
+
+from TAScheduler.models import User, UserType, Course, CourseSection, LabSection
 
 
 class LabsDelete(TASAcceptanceTestCase[LabError]):
@@ -9,11 +16,90 @@ class LabsDelete(TASAcceptanceTestCase[LabError]):
         self.client = Client()
         self.session = self.client.session
 
+        # Add users
+        self.admin_user = User.objects.create(
+            univ_id='josiahth',
+            password='password',
+            type=UserType.ADMIN,
+            tmp_password=False
+        )
+
+        # Add prerequisite objects
+        self.course = Course.objects.create(
+            course_code='361',
+            course_name='Software Engineering',
+            admin_id=self.admin_user,
+        )
+
+        self.ta_user = User.objects.create(
+            univ_id='nleverence',
+            password='password',
+            type=UserType.TA,
+            tmp_password=False
+        )
+
+        self.prof_user = User.objects.create(
+            univ_id='rock',
+            password='password',
+            type=UserType.PROF,
+            tmp_password=False
+        )
+
+        self.section = CourseSection.objects.create(
+            course_section_code='201',
+            course_id=self.course,
+        )
+
+        self.lab_partial = LabSection.objects.create(
+            lab_section_code='901',
+            course_section_id=self.section,
+        )
+
+        self.lab_full = LabSection.objects.create(
+            lab_section_code='901',
+            course_section_id=self.section,
+            lab_days='MWF',
+            lab_time='2-4',
+            ta_id=self.ta_user,
+        )
+
+        # Set current user
+        self.session['user_id'] = self.admin_user.user_id
+        self.session.save()
+
     def test_redirects_professor(self):
-        pass
+        self.session['user_id'] = self.prof_user.user_id
+        self.session.save()
+
+        resp = self.client.post(reverse('labs-delete', args=[self.lab_full.course_section_id]))
+
+        self.assertContainsMessage(resp, Message(
+            'You do not have permission to delete lab sections',
+            Message.Type.ERROR,
+        ))
+
+        self.assertRedirects(resp, reverse('labs-directory'))
 
     def test_redirects_ta(self):
-        pass
+        self.session['user_id'] = self.ta_user.user_id
+        self.session.save()
 
-    def test_context_contains_lab(self):
-        pass
+        resp = self.client.post(reverse('labs-delete', args=[self.lab_full.course_section_id]))
+
+        self.assertContainsMessage(resp, Message(
+            'You do not have permission to delete lab sections',
+            Message.Type.ERROR,
+        ))
+
+        self.assertRedirects(resp, reverse('labs-directory'))
+
+    def test_removes_database(self):
+        resp = self.client.post(reverse('labs-delete', args=[self.lab_full.course_section_id]))
+
+        labs: List[LabSection] = list(LabSection.objects.all())
+
+        self.assertEqual(1, len(labs), 'Did not remove lab section')
+
+        self.assertContainsMessage(resp, Message(
+            'Successfully deleted lab section'
+        ))

--- a/TAScheduler/acceptance_tests/labs/test_delete.py
+++ b/TAScheduler/acceptance_tests/labs/test_delete.py
@@ -1,0 +1,19 @@
+from TAScheduler.acceptance_tests.acceptance_base import TASAcceptanceTestCase
+from TAScheduler.viewsupport.errors import LabError
+from django.test import Client
+
+
+class LabsDelete(TASAcceptanceTestCase[LabError]):
+
+    def setUp(self):
+        self.client = Client()
+        self.session = self.client.session
+
+    def test_redirects_professor(self):
+        pass
+
+    def test_redirects_ta(self):
+        pass
+
+    def test_context_contains_lab(self):
+        pass

--- a/TAScheduler/acceptance_tests/labs/test_directory.py
+++ b/TAScheduler/acceptance_tests/labs/test_directory.py
@@ -1,0 +1,13 @@
+from TAScheduler.acceptance_tests.acceptance_base import TASAcceptanceTestCase
+from TAScheduler.viewsupport.errors import LabError
+from django.test import Client
+
+
+class LabsDelete(TASAcceptanceTestCase[LabError]):
+
+    def setUp(self):
+        self.client = Client()
+        self.session = self.client.session
+
+    def test_context_contains_labs(self):
+        pass

--- a/TAScheduler/acceptance_tests/labs/test_directory.py
+++ b/TAScheduler/acceptance_tests/labs/test_directory.py
@@ -1,6 +1,13 @@
+from django.test import Client
+from django.shortcuts import reverse
+
+from typing import List
+
 from TAScheduler.acceptance_tests.acceptance_base import TASAcceptanceTestCase
 from TAScheduler.viewsupport.errors import LabError
-from django.test import Client
+from TAScheduler.viewsupport.message import Message, MessageQueue
+
+from TAScheduler.models import User, UserType, Course, CourseSection, LabSection
 
 
 class LabsDelete(TASAcceptanceTestCase[LabError]):
@@ -9,5 +16,50 @@ class LabsDelete(TASAcceptanceTestCase[LabError]):
         self.client = Client()
         self.session = self.client.session
 
+        # Add users
+        self.admin_user = User.objects.create(
+            univ_id='josiahth',
+            password='password',
+            type=UserType.ADMIN,
+            tmp_password=False
+        )
+
+        # Add prerequisite objects
+        self.course = Course.objects.create(
+            course_code='361',
+            course_name='Software Engineering',
+            admin_id=self.admin_user,
+        )
+
+        self.section = CourseSection.objects.create(
+            course_section_code='201',
+            course_id=self.course,
+        )
+
+        self.lab_partial = LabSection.objects.create(
+            lab_section_code='901',
+            course_section_id=self.section,
+        )
+
+        self.lab_full = LabSection.objects.create(
+            lab_section_code='901',
+            course_section_id=self.section,
+            lab_days='MWF',
+            lab_time='2-4',
+            ta_id=self.ta_user,
+        )
+
+        # Set current user
+        self.session['user_id'] = self.admin_user.user_id
+        self.session.save()
+
     def test_context_contains_labs(self):
-        pass
+        resp = self.client.get(reverse('labs-directory'))
+
+        labs = resp.context.getlist('labs')
+
+        for li in range(len(labs)):
+            self.assertTrue(isinstance(labs[li], LabSection), msg='Returned non lab object')
+
+        self.assertEqual(2, len(labs), 'Did not return the correct number of lab arguments')
+

--- a/TAScheduler/acceptance_tests/labs/test_edit.py
+++ b/TAScheduler/acceptance_tests/labs/test_edit.py
@@ -3,7 +3,7 @@ from TAScheduler.viewsupport.errors import LabError
 from django.test import Client
 
 
-class LabsCreate(TASAcceptanceTestCase[LabError]):
+class LabsEdit(TASAcceptanceTestCase[LabError]):
 
     def setUp(self):
         self.client = Client()

--- a/TAScheduler/acceptance_tests/labs/test_edit.py
+++ b/TAScheduler/acceptance_tests/labs/test_edit.py
@@ -1,0 +1,36 @@
+from TAScheduler.acceptance_tests.acceptance_base import TASAcceptanceTestCase
+from TAScheduler.viewsupport.errors import LabError
+from django.test import Client
+
+
+class LabsCreate(TASAcceptanceTestCase[LabError]):
+
+    def setUp(self):
+        self.client = Client()
+        self.session = self.client.session
+
+    def test_create_without_days_times(self):
+        pass
+
+    def test_create_full(self):
+        pass
+
+    def test_ta_redirects(self):
+        pass
+
+    def test_rejects_missing_code(self):
+        pass
+
+    def test_rejects_non_digit_code(self):
+        pass
+
+    def test_rejects_mislengthed_code(self):
+        # Test that code lengths must be 3
+        pass
+
+    def test_rejects_missing_section(self):
+        pass
+
+    def test_rejects_professor_change_non_assignments(self):
+        # A professor can edit lab sections, but only their assignments
+        pass

--- a/TAScheduler/viewsupport/errors.py
+++ b/TAScheduler/viewsupport/errors.py
@@ -154,3 +154,28 @@ class SectionError:
     def place_tas(self) -> bool:
         return self._place is SectionError.Place.TAS
 
+
+class LabError:
+    """
+    Represents Errors than can be displayed on the lab section creation and editing pages.
+    """
+
+    class Place(Enum):
+        CODE = 0
+        SECTION = 1
+
+    def __init__(self, msg: str, place: Place):
+        self._msg = msg
+        self._place = place
+
+    def error(self) -> str:
+        return self._msg
+
+    def place(self) -> Place:
+        return self._place
+
+    def place_code(self) -> bool:
+        return self._place is LabError.Place.CODE
+
+    def place_section(self) -> bool:
+        return self._place is LabError.Place.SECTION


### PR DESCRIPTION
## Adds Acceptance tests for all lab views:
- create
- delete
- edit
- view
- directory

## Also adds:
- LabError  
  Represents the errors that can be sent from the server to the user for invalid input.
- TAScheduler.acceptance_tests.acceptance_base.TAAcceptanceTestCase  
  `TestCase` class that is specialized to our use cases for application code,
  and which is generic over the type of error that the views can return to the
  user.