### PR TITLE
Skills Template

### DIFF
--- a/TAScheduler/views/__init__.py
+++ b/TAScheduler/views/__init__.py
@@ -34,6 +34,10 @@ from TAScheduler.views.courses.directory import CoursesDirectory
 from TAScheduler.views.courses.edit import CoursesEdit
 from TAScheduler.views.courses.view import CoursesView
 
+from TAScheduler.views.skills.create import SkillsCreate
+from TAScheduler.views.skills.delete import SkillsDelete
+from TAScheduler.views.skills.directory import SkillsDirectory
+
 from TAScheduler.views.dashboards import ta
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 

--- a/TAScheduler/views/skills/create.py
+++ b/TAScheduler/views/skills/create.py
@@ -1,0 +1,15 @@
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.views import View
+from django.shortcuts import render, redirect, reverse
+from typing import List, Union
+
+from TAScheduler.models import Skill
+from TAScheduler.ClassDesign.LoginUtility import LoginUtility, UserType
+from TAScheduler.viewsupport.message import Message, MessageQueue
+from TAScheduler.viewsupport.navbar import AdminItems
+
+
+class SkillsCreate(View):
+
+    def post(self, request: HttpRequest) -> Union[HttpResponse, HttpResponseRedirect]:
+        return redirect(reverse('skills-directory'))

--- a/TAScheduler/views/skills/delete.py
+++ b/TAScheduler/views/skills/delete.py
@@ -1,0 +1,15 @@
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.views import View
+from django.shortcuts import render, redirect, reverse
+from typing import List, Union
+
+from TAScheduler.models import Skill
+from TAScheduler.ClassDesign.LoginUtility import LoginUtility, UserType
+from TAScheduler.viewsupport.message import Message, MessageQueue
+from TAScheduler.viewsupport.navbar import AdminItems
+
+
+class SkillsDelete(View):
+
+    def get(self, request: HttpRequest, skill_id: int) -> Union[HttpResponse, HttpResponseRedirect]:
+        return redirect(reverse('skills-directory'))

--- a/TAScheduler/views/skills/directory.py
+++ b/TAScheduler/views/skills/directory.py
@@ -1,0 +1,31 @@
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.views import View
+from django.shortcuts import render, redirect, reverse
+from typing import List, Union
+
+from TAScheduler.models import Skill
+from TAScheduler.ClassDesign.LoginUtility import LoginUtility, UserType
+from TAScheduler.viewsupport.message import Message, MessageQueue
+from TAScheduler.viewsupport.navbar import AdminItems
+
+
+class SkillsDirectory(View):
+
+    def get(self, request: HttpRequest) -> Union[HttpResponse, HttpResponseRedirect]:
+        user = LoginUtility.get_user_and_validate_by_user_id(
+            request.session,
+            [UserType.ADMIN],
+            reverse('index'),
+            Message('You do not have permission to edit skills', Message.Type.ERROR)
+        )
+
+        if type(user) is HttpResponseRedirect:
+            return user
+
+        return render(request, 'pages/skills.html', {
+            'self': user,
+            'navbar_items': AdminItems.SKILLS.items_iterable_except(),
+            'message': MessageQueue.drain(request.session),
+
+            'skills': list(Skill.objects.all()),
+        })

--- a/TAScheduler/views/users/edit.py
+++ b/TAScheduler/views/users/edit.py
@@ -8,6 +8,7 @@ from TAScheduler.viewsupport.errors import UserEditError, UserEditPlace
 from TAScheduler.ClassDesign.UserAPI import UserAPI, UserType
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.models import Skill
 
 
 # Obviously just a stub, needed to make login acceptance tests pass.
@@ -36,6 +37,8 @@ class UserEdit(View):
             'navbar_items': AdminItems.items_iterable(),  # TODO Change based on user type later
             'self': user,
             'edit': to_edit,
+
+            'skills': list(Skill.objects.all()),
         })
 
     def post(self, request: HttpRequest, user_id: int):
@@ -91,6 +94,17 @@ class UserEdit(View):
         except KeyError:
             fields['new_password'] = None
 
+        def render_error(error: UserEditError):
+            return render(request, 'pages/users/edit_create.html', {
+                'navbar_items': AdminItems.items_iterable(),  # TODO change based on user type
+                'self': user,
+                'edit': to_edit,
+
+                'skills': list(Skill.objects.all()),
+
+                'error': error,
+            })
+
         # Check error cases
         if fields['new_password'] is not None and len(fields['new_password']) > 0:
             # Attempting to change password
@@ -107,60 +121,30 @@ class UserEdit(View):
                 })
 
             if fields['old_password'] is None or str(to_edit.password) != fields['old_password']:
-                return render(request, 'pages/users/edit_create.html', {
-                    'navbar_items': AdminItems.items_iterable(),  # TODO change based on user type
-                    'self': user,
-                    'edit': to_edit,
-                    'error': UserEditError('Incorrect password', UserEditError.Place.PASSWORD),
-                })
+                return render_error(UserEditError('Incorrect password', UserEditError.Place.PASSWORD))
 
             if len(fields['new_password']) < 8:
-                return render(request, 'pages/users/edit_create.html', {
-                    'navbar_items': AdminItems.items_iterable(),  # TODO change based on user type
-                    'self': user,
-                    'edit': to_edit,
-                    'error': UserEditError('New Password needs to be 8 or more characters.', UserEditError.Place.PASSWORD),
-                })
+                return render_error(UserEditError('New Password needs to be 8 or more characters.', UserEditError.Place.PASSWORD))
 
             LoginUtility.update_password(to_edit, fields['new_password'])
             MessageQueue.push(request.session, Message('Password Updated'))
             # Done changing password
 
         if fields['old_password'] is not None and len(fields['old_password']) > 0 and (fields['new_password'] is None or len(fields['new_password']) == 0):
-            return render(request, 'pages/users/edit_create.html', {
-                'navbar_items': AdminItems.items_iterable(),  # TODO change based on user type
-                'self': user,
-                'edit': to_edit,
-                'error': UserEditError('New password can\'t be empty.', UserEditPlace.PASSWORD),
-            })
+            return render_error(UserEditError('New password can\'t be empty.', UserEditPlace.PASSWORD))
 
         if fields['univ_id'] is None or len(fields['univ_id']) == 0:
-            return render(request, 'pages/users/edit_create.html', {
-                'navbar_items': AdminItems.items_iterable(),  # TODO change based on user type
-                'self': user,
-                'edit': to_edit,
-                'error': UserEditError('You can\'t remove a user\'s username.', UserEditPlace.USERNAME),
-            })
+            return render_error(UserEditError('You can\'t remove a user\'s username.', UserEditPlace.USERNAME))
 
         if fields['univ_id'] != to_edit.username:
             if UserAPI.check_user_type(user) != UserType.ADMIN:
-                return render(request, 'pages/users/edit_create.html', {
-                    'navbar_items': AdminItems.items_iterable(),  # TODO change based on user type
-                    'self': user,
-                    'edit': to_edit,
-                    'error': UserEditError('You cannot change your own username', UserEditPlace.USERNAME),
-                })
+                return render_error(UserEditError('You cannot change your own username', UserEditPlace.USERNAME))
 
             if len(fields['univ_id']) > 20:
-                return render(request, 'pages/users/edit_create.html', {
-                    'navbar_items': AdminItems.items_iterable(),  # TODO change based on user type
-                    'self': user,
-                    'edit': to_edit,
-                    'error': UserEditError(
+                return render_error(UserEditError(
                         'A username may not be longer than 20 characters.',
                         UserEditPlace.USERNAME
-                    ),
-                })
+                    ))
 
             to_edit.username = fields['univ_id']
             to_edit.save()
@@ -172,15 +156,10 @@ class UserEdit(View):
             print(f'Phone number extracted: ' + fields['phone'])
 
             if len(fields['phone']) > 0 and len(fields['phone']) != 10:
-                return render(request, 'pages/users/edit_create.html', {
-                    'navbar_items': AdminItems.items_iterable(),  # TODO change based on user type
-                    'self': user,
-                    'edit': to_edit,
-                    'error': UserEditError(
+                return render_error(UserEditError(
                         'Phone number needs to be exactly 10 digits long.',
                         UserEditPlace.PHONE
-                    ),
-                })
+                    ))
 
         UserAPI.update_user(to_edit, fields['l_name'], fields['f_name'], fields['phone'])
 
@@ -190,15 +169,10 @@ class UserEdit(View):
         if fields['user_type'] is not None:
             # Chane user type
             if UserAPI.check_user_type(user) != UserType.ADMIN:
-                return render(request, 'pages/users/edit_create.html', {
-                    'navbar_items': AdminItems.items_iterable(),  # TODO change based on user type
-                    'self': user,
-                    'edit': to_edit,
-                    'error': UserEditError(
+                return render_error(UserEditError(
                         'Only admins may change user types',
                         UserEditPlace.TYPE
-                    ),
-                })
+                    ))
 
             # to_edit.type = fields['user_type']
 

--- a/TAScheduler/viewsupport/navbar.py
+++ b/TAScheduler/viewsupport/navbar.py
@@ -55,6 +55,7 @@ class AdminItems(Enum):
     COURSES = 2
     SECTIONS = 3
     LABS = 4
+    SKILLS = 5
 
     def get_item(self):
         if self == AdminItems.HOME:
@@ -67,6 +68,8 @@ class AdminItems(Enum):
             return NavbarItem('course sections', reverse('sections-directory'), icon='kanban-fill')
         elif self == AdminItems.LABS:
             return NavbarItem('labs', reverse('labs-directory'), icon='bar-chart-fill')
+        elif self == AdminItems.SKILLS:
+            return NavbarItem('skills', reverse('skills-directory'), icon='award-fill')
 
     def map_disable(self):
         """

--- a/project/urls.py
+++ b/project/urls.py
@@ -52,4 +52,10 @@ urlpatterns = [
     path('labs/<int:lab_id>/', LabsView.as_view(), name='labs-view'),
     path('labs/create/', LabsCreate.as_view(), name='labs-create'),
     path('labs/', LabsDirectory.as_view(), name='labs-directory'),
+
+    # Skills resource management
+    path('skills/<int:skill_id>/delete', SkillsDelete.as_view(), name='skills-delete'),
+    path('skills/create', SkillsCreate.as_view(), name='skills-create'),
+    path('skills/', SkillsDirectory.as_view(), name='skills-directory'),
+
 ]

--- a/templates/pages/skills.html
+++ b/templates/pages/skills.html
@@ -1,0 +1,60 @@
+{% extends 'app_base.html' %}
+
+{% comment %}
+
+Skill management for admins:
+
+Context:
+- skills: List[Skill]
+
+{% endcomment %}
+
+{% block application_pane %}
+
+<div class="row">
+
+    <h3 class="mt-2 mb-3">All Skills</h3>
+
+    <div class="list-group">
+        {# Existing Skills #}
+        {% for skill in skills %}
+
+            <div class="list-group-item d-flex align-items-center">
+
+                <span class="h6 me-auto">{{ skill.name }}</span>
+
+                <a class="btn btn-danger"
+                   href="{% url 'skills-delete' skill.id %}">
+                    <i class="bi bi-trash-fill"></i>
+                </a>
+
+            </div>
+
+        {% endfor %}
+
+        {# Create New Skill #}
+        <form class="form needs-validation list-group-item"
+              action="{% url 'skills-create' %}"
+              method="post"
+              novalidate>
+            {% csrf_token %}
+
+            {# <label for="new_skill" class="form-label">New Skill</label> #}
+            <div class="input-group has-validation">
+                <input type="text" class="form-control"
+                       id="new_skill" name="new_skill"
+                       placeholder="name"
+                       required/>
+
+                <input type="submit" class="btn btn-primary" value="create">
+
+                <div class="invalid-feedback">You cannot create a skill without a name</div>
+            </div>
+
+        </form>
+    </div>
+</div>
+
+{% include 'partials/validate.html' %}
+
+{% endblock application_pane %}

--- a/templates/pages/users/edit_create.html
+++ b/templates/pages/users/edit_create.html
@@ -143,7 +143,7 @@ Post returns the following variables:
 
             </div>
 
-            {% if edit and edit.type == 'T' %}
+            {% if edit and edit == self and edit.type == 'T' %}
                 <div class="col-12 col-sm-6">
 
                     {# Skills #}

--- a/templates/pages/users/edit_create.html
+++ b/templates/pages/users/edit_create.html
@@ -9,6 +9,7 @@ Context Variables:
 - self: User                        The User object that is viewing the page
 - edit: Optional[User]              the existing user
 - new_user_pass: Optional[str]      the new password to be used when creating a user (does nothing if edit is not None)
+- skills: List[Skill]               A list of skills that the user could have, only used if edit.type == TA and edit == self
 - error: Optional[UserEditError]:   Used on post request failure to indicate server side validation failed
 
 To use in the following configurations set these variables:
@@ -106,44 +107,66 @@ Post returns the following variables:
         {# first / last name #}
         <div class="mb-3 row">
 
-            {# first name #}
             <div class="col-12 col-sm-6">
+                {# first name #}
                 <label for="f_name" class="form-label">first name</label>
-                <input type="text" class="form-control" name="f_name"
+                <input type="text" class="form-control mb-3" name="f_name"
                 {% if edit is not None %}
                         value="{{ edit.f_name }}"
                 {% endif %}
                 >
-            </div>
 
-            {# last name #}
-            <div class="col-12 col-sm-6">
+                {# last name #}
                 <label for="l_name" class="form-label">last name</label>
-                <input type="text" class="form-control" name="l_name"
+                <input type="text" class="form-control mb-3" name="l_name"
                         {% if edit is not None %}
                        value="{{ edit.l_name }}"
                         {% endif %}
                 >
+
+                <label for="phone" class="form-label">phone number</label>
+                <div class="input-group has-validation mb-3">
+                    <div class="input-group-text">+1 </div>
+                    <input type="text" pattern="[0-9]{10}"
+                           class="form-control" id="phone" name="phone"
+                            {% if edit is not None %}
+                           value=""{{ edit.phone }}
+                            {% endif %}
+                    >
+                    {% if error is not None and error.place.phone %}
+                        <div class="invalid-feedback is-invalid">{{ error.message }}</div>
+                    {% else %}
+                        <div class="invalid-feedback">You must input all 10 digits of a phone number without any special characters</div>
+                    {% endif %}
+                </div>
+                {# phone #}
+
             </div>
+
+            {% if edit and edit.type == 'T' %}
+                <div class="col-12 col-sm-6">
+
+                    {# Skills #}
+                    <label class="form-label">skills</label>
+                    <div class="list-group">
+                        {% for skill in skills %}
+
+                            <label class="list-group-item">
+                                <input type="checkbox"
+                                       class="form-check-control me-1"
+                                       name="skill_ids" id="{{ skill.id }}" value="{{ skill.id }}"
+                                       {% if skill in edit.skills.all %}checked{% endif %}
+                                >
+                                <span class="form-label">{{ skill.name }}</span>
+                            </label>
+
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endif %}
         </div>
 
-        {# phone #}
         <div class="mb-3">
-            <label for="phone" class="form-label">phone number</label>
-            <div class="input-group has-validation">
-                <div class="input-group-text">+1 </div>
-                <input type="text" pattern="[0-9]{10}"
-                       class="form-control" id="phone" name="phone"
-                {% if edit is not None %}
-                    value=""{{ edit.phone }}
-                {% endif %}
-                >
-                {% if error is not None and error.place.phone %}
-                    <div class="invalid-feedback is-invalid">{{ error.message }}</div>
-                {% else %}
-                    <div class="invalid-feedback">You must input all 10 digits of a phone number without any special characters</div>
-                {% endif %}
-            </div>
         </div>
 
         {# password (can only be changed by self, seen by admin if new user) #}

--- a/templates/partials/list_row/user.html
+++ b/templates/partials/list_row/user.html
@@ -9,7 +9,7 @@ Takes the following context:
 <div class="list-group-item d-flex flex-column flex-sm-row align-items-sm-center">
     {# Left #}
     <div class="me-sm-auto d-flex flex-row flex-sm-column align-items-center align-items-sm-start justify-content-between justify-content-sm-start">
-        <h4 class="mb-0">{{ user.id }}</h4>
+        <h4 class="mb-0">{{ user.username }}</h4>
         <!-- <hr class="mb-0 d-none d-sm-inline "/> -->
         <p class="mb-0">{{ user.f_name }} {{ user.l_name }} </p>
         <em>{{ user.get_type_display }}</em>


### PR DESCRIPTION
Adds skills management template and a place in the user edit page to choose one's own skills.

Also fixes a small issue with user directory where user row displayed the primary key of user instead of their username.

## Skill management

<img width="1004" alt="Screen Shot 2021-05-09 at 17 36 44" src="https://user-images.githubusercontent.com/7718949/117589091-220dce80-b0ed-11eb-9872-9413574ea483.png">

## User edit page

![image](https://user-images.githubusercontent.com/7718949/117604633-8182d300-b11b-11eb-9796-06af27a5a75e.png)

## Future Work

- Add a list of skills to user cards if they are a TA, which can be turned off if needed
