### PR TITLE
Update navbar items creation

### DIFF
--- a/TAScheduler/views/__init__.py
+++ b/TAScheduler/views/__init__.py
@@ -3,9 +3,6 @@ from django.views import View
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from typing import List
 
-from TAScheduler.viewsupport.navbar import AdminItems
-from TAScheduler.viewsupport.message import MessageQueue
-
 # Reexport Views from Submodules
 from TAScheduler.views.login import Login
 from TAScheduler.views.logout import Logout

--- a/TAScheduler/views/courses/create.py
+++ b/TAScheduler/views/courses/create.py
@@ -7,7 +7,7 @@ from string import digits
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility, UserType
 from TAScheduler.ClassDesign.CourseAPI import CourseAPI
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.viewsupport.errors import CourseEditPlace, CourseEditError
 
 class CoursesCreate(View):
@@ -28,7 +28,7 @@ class CoursesCreate(View):
 
         return render(request, 'pages/courses/edit_create.html', {
             'self': user,
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
             'messages': MessageQueue.drain(request.session),
         })
 
@@ -54,7 +54,7 @@ class CoursesCreate(View):
         if course_code is None or len(course_code) != 3:
             return render(request, 'pages/courses/edit_create.html', {
                 'self': user,
-                'navbar_items': AdminItems.items_iterable(),
+                'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
                 'messages': MessageQueue.drain(request.session),
 
                 'error': CourseEditError(
@@ -66,7 +66,7 @@ class CoursesCreate(View):
         if course_name is None:
             return render(request, 'pages/courses/edit_create.html', {
                 'self': user,
-                'navbar_items': AdminItems.items_iterable(),
+                'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
                 'messages': MessageQueue.drain(request.session),
 
                 'error': CourseEditError(

--- a/TAScheduler/views/courses/create.py
+++ b/TAScheduler/views/courses/create.py
@@ -28,7 +28,7 @@ class CoursesCreate(View):
 
         return render(request, 'pages/courses/edit_create.html', {
             'self': user,
-            'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'messages': MessageQueue.drain(request.session),
         })
 
@@ -54,7 +54,7 @@ class CoursesCreate(View):
         if course_code is None or len(course_code) != 3:
             return render(request, 'pages/courses/edit_create.html', {
                 'self': user,
-                'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
+                'navbar_items': AllItems.for_type(user.type).iter(),
                 'messages': MessageQueue.drain(request.session),
 
                 'error': CourseEditError(
@@ -66,7 +66,7 @@ class CoursesCreate(View):
         if course_name is None:
             return render(request, 'pages/courses/edit_create.html', {
                 'self': user,
-                'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
+                'navbar_items': AllItems.for_type(user.type).iter(),
                 'messages': MessageQueue.drain(request.session),
 
                 'error': CourseEditError(

--- a/TAScheduler/views/courses/delete.py
+++ b/TAScheduler/views/courses/delete.py
@@ -37,7 +37,7 @@ class CoursesDelete(View):
 
         return render(request, 'pages/courses/delete.html', {
             'self': user,
-            'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'course': course,

--- a/TAScheduler/views/courses/delete.py
+++ b/TAScheduler/views/courses/delete.py
@@ -6,7 +6,7 @@ from typing import List, Union
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.ClassDesign.UserAPI import UserType
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.ClassDesign.CourseAPI import Course, CourseAPI
 
 
@@ -37,7 +37,7 @@ class CoursesDelete(View):
 
         return render(request, 'pages/courses/delete.html', {
             'self': user,
-            'navbar_items': AdminItems.COURSES.items_iterable_except(),
+            'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'course': course,

--- a/TAScheduler/views/courses/directory.py
+++ b/TAScheduler/views/courses/directory.py
@@ -6,7 +6,7 @@ from typing import List, Union, Iterable
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.ClassDesign.UserAPI import UserType
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.ClassDesign.CourseAPI import CourseAPI
 from TAScheduler.models import Course
 
@@ -22,7 +22,7 @@ class CoursesDirectory(View):
 
         return render(request, 'pages/courses/directory.html', {
             'self': user,
-            'navbar_items': AdminItems.COURSES.items_iterable_except(),
+            'navbar_items': AllItems.for_type(UserType.ADMIN).without(AllItems.COURSES).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'courses': courses,

--- a/TAScheduler/views/courses/directory.py
+++ b/TAScheduler/views/courses/directory.py
@@ -22,7 +22,7 @@ class CoursesDirectory(View):
 
         return render(request, 'pages/courses/directory.html', {
             'self': user,
-            'navbar_items': AllItems.for_type(UserType.ADMIN).without(AllItems.COURSES).iter(),
+            'navbar_items': AllItems.for_type(user.type).without(AllItems.COURSES).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'courses': courses,

--- a/TAScheduler/views/courses/edit.py
+++ b/TAScheduler/views/courses/edit.py
@@ -37,7 +37,7 @@ class CoursesEdit(View):
 
         return render(request, 'pages/courses/edit_create.html', {
             'self': user,
-            'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'edit': course
@@ -72,7 +72,7 @@ class CoursesEdit(View):
         def render_error(error: CourseEditError):
             return render(request, 'pages/courses/edit_create.html', {
                 'self': user,
-                'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
+                'navbar_items': AllItems.for_type(user.type).iter(),
                 'messages': MessageQueue.drain(request.session),
 
                 'edit': course,

--- a/TAScheduler/views/courses/edit.py
+++ b/TAScheduler/views/courses/edit.py
@@ -7,7 +7,7 @@ from string import digits
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility, UserType
 from TAScheduler.ClassDesign.CourseAPI import CourseAPI, Course
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.viewsupport.errors import CourseEditError, CourseEditPlace
 
 class CoursesEdit(View):
@@ -37,7 +37,7 @@ class CoursesEdit(View):
 
         return render(request, 'pages/courses/edit_create.html', {
             'self': user,
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'edit': course
@@ -72,7 +72,7 @@ class CoursesEdit(View):
         def render_error(error: CourseEditError):
             return render(request, 'pages/courses/edit_create.html', {
                 'self': user,
-                'navbar_items': AdminItems.items_iterable(),
+                'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
                 'messages': MessageQueue.drain(request.session),
 
                 'edit': course,

--- a/TAScheduler/views/courses/view.py
+++ b/TAScheduler/views/courses/view.py
@@ -28,7 +28,7 @@ class CoursesView(View):
 
         return render(request, 'pages/courses/view.html', {
             'self': user,
-            'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'course': course,

--- a/TAScheduler/views/courses/view.py
+++ b/TAScheduler/views/courses/view.py
@@ -6,7 +6,7 @@ from typing import List, Union
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.ClassDesign.UserAPI import UserType
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.ClassDesign.CourseAPI import Course, CourseAPI
 
 class CoursesView(View):
@@ -28,7 +28,7 @@ class CoursesView(View):
 
         return render(request, 'pages/courses/view.html', {
             'self': user,
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(UserType.ADMIN).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'course': course,

--- a/TAScheduler/views/dashboards/ta.py
+++ b/TAScheduler/views/dashboards/ta.py
@@ -5,7 +5,7 @@ from typing import List, Union
 
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.ClassDesign.LabAPI import LabAPI, Lab
 from TAScheduler.ClassDesign.SectionAPI import SectionAPI, Section
 from TAScheduler.ClassDesign.UserAPI import User
@@ -14,7 +14,7 @@ def get(request: HttpRequest, user: User) -> HttpResponse:
     return render(request, 'pages/dashboards/ta.html', {
         "self": user,
         "messages": MessageQueue.drain(request.session),
-        "navbar_items": AdminItems.HOME.items_iterable_except(),
+        "navbar_items": AllItems.for_type(user.type).without(AllItems.HOME),
 
         "message_count": 17,
         "sections": Section.objects.all(),

--- a/TAScheduler/views/labs/create.py
+++ b/TAScheduler/views/labs/create.py
@@ -7,7 +7,7 @@ from string import digits
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.ClassDesign.UserAPI import UserType, User, UserAPI
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.models import Section
 from TAScheduler.viewsupport.errors import LabEditPlace, LabEditError
 from TAScheduler.ClassDesign.LabAPI import LabAPI, Lab
@@ -33,7 +33,7 @@ class LabsCreate(View):
 
         return render(request, 'pages/labs/edit_create.html', {
             'self': user,
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'sections': Section.objects.all(),
@@ -63,7 +63,7 @@ class LabsCreate(View):
         def render_error(error: LabEditError):
             return render(request, 'pages/labs/edit_create.html', {
                 'self': user,
-                'navbar_items': AdminItems.items_iterable(),
+                'navbar_items': AllItems.for_type(user.type).iter(),
                 'messages': MessageQueue.drain(request.session),
 
                 'sections': Section.objects.all(),

--- a/TAScheduler/views/labs/delete.py
+++ b/TAScheduler/views/labs/delete.py
@@ -6,7 +6,7 @@ from typing import List, Union
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.ClassDesign.UserAPI import UserType
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.ClassDesign.LabAPI import LabAPI
 
 class LabsDelete(View):
@@ -36,7 +36,7 @@ class LabsDelete(View):
 
         return render(request, 'pages/labs/view.html', {
             'self': user,
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'lab': lab,

--- a/TAScheduler/views/labs/directory.py
+++ b/TAScheduler/views/labs/directory.py
@@ -6,7 +6,7 @@ from typing import List, Union
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.ClassDesign.UserAPI import UserType
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.ClassDesign.LabAPI import LabAPI, Lab
 
 class LabsDirectory(View):
@@ -21,7 +21,7 @@ class LabsDirectory(View):
 
         return render(request, 'pages/labs/directory.html', {
             'self': user,
-            'navbar_items': AdminItems.LABS.items_iterable_except(),
+            'navbar_items': AllItems.for_type(user.type).without(AllItems.LABS).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'labs': labs,

--- a/TAScheduler/views/labs/edit.py
+++ b/TAScheduler/views/labs/edit.py
@@ -8,7 +8,7 @@ from more_itertools import ilen
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.ClassDesign.UserAPI import UserType, User, UserAPI
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.ClassDesign.LabAPI import LabAPI
 from TAScheduler.ClassDesign.SectionAPI import Section, SectionAPI
 from TAScheduler.viewsupport.errors import LabEditError, LabEditPlace
@@ -39,7 +39,7 @@ class LabsEdit(View):
 
         return render(request, 'pages/labs/edit_create.html', {
             'self': user,
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'edit': lab,
@@ -80,7 +80,7 @@ class LabsEdit(View):
         def render_error(error: LabEditError):
             return render(request, 'pages/labs/edit_create.html', {
                 'self': user,
-                'navbar_items': AdminItems.items_iterable(),
+                'navbar_items': AllItems.for_type(user.type).iter(),
                 'messages': MessageQueue.drain(request.session),
 
                 'sections': Section.objects.all(),

--- a/TAScheduler/views/labs/view.py
+++ b/TAScheduler/views/labs/view.py
@@ -5,7 +5,7 @@ from typing import Union
 
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.ClassDesign.LabAPI import LabAPI
 
 class LabsView(View):
@@ -27,7 +27,7 @@ class LabsView(View):
 
         return render(request, 'pages/labs/view.html', {
             'self': user,
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'lab': lab,

--- a/TAScheduler/views/section/create.py
+++ b/TAScheduler/views/section/create.py
@@ -9,7 +9,7 @@ from TAScheduler.ClassDesign.UserAPI import User, UserType, UserAPI
 from TAScheduler.ClassDesign.CourseAPI import Course, CourseAPI
 from TAScheduler.ClassDesign.SectionAPI import Section, SectionAPI
 from TAScheduler.viewsupport.message import Message, MessageQueue
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.viewsupport.errors import SectionEditPlace, SectionEditError
 from TAScheduler.models import User, UserType, Course
 
@@ -28,7 +28,7 @@ class SectionsCreate(View):
 
         return render(request, 'pages/sections/edit_create.html', {
             'self': user,
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
 
             'courses': Course.objects.all(),
             'professors': User.objects.filter(type=UserType.PROF),
@@ -59,7 +59,7 @@ class SectionsCreate(View):
         if course is None:
             return render(request, 'pages/sections/edit_create.html', {
                 'self': user,
-                'navbar_items': AdminItems.items_iterable(),
+                'navbar_items': AllItems.for_type(user.type).iter(),
 
                 'courses': Course.objects.all(),
                 'professors': User.objects.filter(type=UserType.PROF),
@@ -71,7 +71,7 @@ class SectionsCreate(View):
         if section_code is None:
             return render(request, 'pages/sections/edit_create.html', {
                 'self': user,
-                'navbar_items': AdminItems.items_iterable(),
+                'navbar_items': AllItems.for_type(user.type).iter(),
 
                 'courses': Course.objects.all(),
                 'professors': User.objects.filter(type=UserType.PROF),
@@ -89,7 +89,7 @@ class SectionsCreate(View):
         except IntegrityError:
             return render(request, 'pages/sections/edit_create.html', {
                 'self': user,
-                'navbar_items': AdminItems.items_iterable(),
+                'navbar_items': AllItems.for_type(user.type).iter(),
 
                 'courses': Course.objects.all(),
                 'professors': User.objects.filter(type=UserType.PROF),

--- a/TAScheduler/views/section/delete.py
+++ b/TAScheduler/views/section/delete.py
@@ -7,7 +7,7 @@ from typing import List, Union
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.ClassDesign.UserAPI import UserType
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 
 from TAScheduler.ClassDesign.SectionAPI import SectionAPI
 
@@ -36,7 +36,7 @@ class SectionsDelete(View):
 
         return render(request, 'pages/sections/delete.html', {
             'self': user,
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'to_delete': section,

--- a/TAScheduler/views/section/directory.py
+++ b/TAScheduler/views/section/directory.py
@@ -6,7 +6,7 @@ from typing import Union
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.ClassDesign.SectionAPI import Section
 from TAScheduler.viewsupport.message import MessageQueue
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 
 
 class SectionsDirectory(View):
@@ -18,7 +18,7 @@ class SectionsDirectory(View):
 
         return render(request, 'pages/sections/directory.html', {
             'self': user,
-            'navbar_items': AdminItems.SECTIONS.items_iterable_except(),
+            'navbar_items': AllItems.for_type(user.type).without(AllItems.SECTIONS).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'sections': list(Section.objects.all()),

--- a/TAScheduler/views/section/edit.py
+++ b/TAScheduler/views/section/edit.py
@@ -9,7 +9,7 @@ from TAScheduler.ClassDesign.UserAPI import User, UserType, UserAPI
 from TAScheduler.ClassDesign.CourseAPI import Course, CourseAPI
 from TAScheduler.ClassDesign.SectionAPI import Section, SectionAPI
 from TAScheduler.viewsupport.message import Message, MessageQueue
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.viewsupport.errors import SectionEditError, SectionEditPlace
 from TAScheduler.models import User, UserType, Course
 
@@ -37,7 +37,7 @@ class SectionsEdit(View):
 
         return render(request, 'pages/sections/edit_create.html', {
             'self': user,
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'section': edit,
@@ -80,7 +80,7 @@ class SectionsEdit(View):
         if course is None:
             return render(request, 'pages/sections/edit_create.html', {
                 'self': user,
-                'navbar_items': AdminItems.items_iterable(),
+                'navbar_items': AllItems.for_type(user.type).iter(),
                 'messages': MessageQueue.drain(request.session),
 
                 'section': edit,
@@ -95,7 +95,7 @@ class SectionsEdit(View):
         if section_code is None:
             return render(request, 'pages/sections/edit_create.html', {
                 'self': user,
-                'navbar_items': AdminItems.items_iterable(),
+                'navbar_items': AllItems.for_type(user.type).iter(),
                 'messages': MessageQueue.drain(request.session),
 
                 'section': edit,
@@ -118,7 +118,7 @@ class SectionsEdit(View):
             edit.refresh_from_db()
             return render(request, 'pages/sections/edit_create.html', {
                 'self': user,
-                'navbar_items': AdminItems.items_iterable(),
+                'navbar_items': AllItems.for_type(user.type).iter(),
                 'messages': MessageQueue.drain(request.session),
 
                 'section': edit,

--- a/TAScheduler/views/section/view.py
+++ b/TAScheduler/views/section/view.py
@@ -6,7 +6,7 @@ from typing import Union
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.ClassDesign.SectionAPI import Section, SectionAPI
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 
 
 class SectionsView(View):
@@ -27,7 +27,7 @@ class SectionsView(View):
 
         return render(request, 'pages/sections/view.html', {
             'self': user,
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'section': section,

--- a/TAScheduler/views/skills/create.py
+++ b/TAScheduler/views/skills/create.py
@@ -6,7 +6,7 @@ from typing import List, Union
 from TAScheduler.models import Skill
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility, UserType
 from TAScheduler.viewsupport.message import Message, MessageQueue
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 
 
 class SkillsCreate(View):

--- a/TAScheduler/views/skills/delete.py
+++ b/TAScheduler/views/skills/delete.py
@@ -6,7 +6,7 @@ from typing import List, Union
 from TAScheduler.models import Skill
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility, UserType
 from TAScheduler.viewsupport.message import Message, MessageQueue
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 
 
 class SkillsDelete(View):

--- a/TAScheduler/views/skills/directory.py
+++ b/TAScheduler/views/skills/directory.py
@@ -6,7 +6,7 @@ from typing import List, Union
 from TAScheduler.models import Skill
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility, UserType
 from TAScheduler.viewsupport.message import Message, MessageQueue
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 
 
 class SkillsDirectory(View):
@@ -24,7 +24,7 @@ class SkillsDirectory(View):
 
         return render(request, 'pages/skills.html', {
             'self': user,
-            'navbar_items': AdminItems.SKILLS.items_iterable_except(),
+            'navbar_items': AllItems.for_type(user.type).without(AllItems.SKILLS).iter(),
             'message': MessageQueue.drain(request.session),
 
             'skills': list(Skill.objects.all()),

--- a/TAScheduler/views/users/create.py
+++ b/TAScheduler/views/users/create.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.ClassDesign.UserAPI import UserAPI, UserType
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.viewsupport.errors import UserEditError, UserEditPlace
 from TAScheduler.viewsupport.message import Message, MessageQueue
 from TAScheduler.ClassDesign.Util import Util
@@ -30,7 +30,7 @@ class UserCreate(View):
 
         return render(request, 'pages/users/edit_create.html', {
             'self': maybe_user,
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(maybe_user.type).iter(),
             'new_user_pass': tmp_pass,
             'messages': MessageQueue.drain(request.session),
         })

--- a/TAScheduler/views/users/delete.py
+++ b/TAScheduler/views/users/delete.py
@@ -6,7 +6,7 @@ from typing import List, Union
 from TAScheduler.ClassDesign.UserAPI import UserAPI, UserType
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.viewsupport.message import Message, MessageQueue
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 
 
 class UserDelete(View):
@@ -35,7 +35,7 @@ class UserDelete(View):
         return render(request, 'pages/users/delete.html', {
             'self': user,
             'messages': MessageQueue.drain(request.session),
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'to_delete': to_delete,
         })
 

--- a/TAScheduler/views/users/directory.py
+++ b/TAScheduler/views/users/directory.py
@@ -7,7 +7,7 @@ from typing import List, Union
 from TAScheduler.ClassDesign.UserAPI import UserAPI, UserType, User
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.viewsupport.message import Message, MessageQueue
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 
 
 class UserDirectory(View):
@@ -19,7 +19,7 @@ class UserDirectory(View):
 
         return render(request, 'pages/users/directory.html', {
             'self': user,
-            'navbar_items': AdminItems.USERS.items_iterable_except(),  # TODO change for other user types
+            'navbar_items': AllItems.for_type(user.type).without(AllItems.USERS).iter(),
             'messages': MessageQueue.drain(request.session),
 
             'users': User.objects.iterator(),  # TODO change to use new function on UserAPI

--- a/TAScheduler/views/users/edit.py
+++ b/TAScheduler/views/users/edit.py
@@ -7,9 +7,8 @@ from TAScheduler.viewsupport.message import Message, MessageQueue
 from TAScheduler.viewsupport.errors import UserEditError, UserEditPlace
 from TAScheduler.ClassDesign.UserAPI import UserAPI, UserType
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 from TAScheduler.models import Skill
-
 
 # Obviously just a stub, needed to make login acceptance tests pass.
 class UserEdit(View):
@@ -34,11 +33,9 @@ class UserEdit(View):
             return redirect(reverse('index'))
 
         return render(request, 'pages/users/edit_create.html', {
-            'navbar_items': AdminItems.items_iterable(),  # TODO Change based on user type later
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'self': user,
             'edit': to_edit,
-
-            'skills': list(Skill.objects.all()),
         })
 
     def post(self, request: HttpRequest, user_id: int):
@@ -115,7 +112,7 @@ class UserEdit(View):
                     Message('You may not change another users password', Message.Type.ERROR)
                 )
                 return render(request, 'pages/users/edit_create.html', {
-                    'navbar_items': AdminItems.items_iterable(),
+                    'navbar_items': AllItems.for_type(user.type).iter(),
                     'self': user,
                     'edit': to_edit,
                 })

--- a/TAScheduler/views/users/view.py
+++ b/TAScheduler/views/users/view.py
@@ -3,7 +3,7 @@ from django.views import View
 from django.shortcuts import render, redirect, reverse
 
 from TAScheduler.viewsupport.message import MessageQueue, Message
-from TAScheduler.viewsupport.navbar import AdminItems
+from TAScheduler.viewsupport.navbar import AllItems
 
 from TAScheduler.ClassDesign.LoginUtility import LoginUtility
 from TAScheduler.ClassDesign.UserAPI import UserAPI
@@ -24,7 +24,7 @@ class UserView(View):
             return redirect(reverse('index'))
 
         return render(request, 'pages/users/view.html', context={
-            'navbar_items': AdminItems.items_iterable(),
+            'navbar_items': AllItems.for_type(user.type).iter(),
             'messages': MessageQueue.drain(request.session),
             'self': user,
             'user': to_display,

--- a/TAScheduler/viewsupport/navbar.py
+++ b/TAScheduler/viewsupport/navbar.py
@@ -61,7 +61,7 @@ class AllItems(Enum):
     SKILLS = 6
 
     @classmethod
-    def for_type(cls, user_type: UserType):
+    def for_type(cls, user_type: Union[UserType, str]):
         """
         Create a new (partially applied) iterator to get the list of navbar items.
 
@@ -71,6 +71,9 @@ class AllItems(Enum):
         or
         AllItems.for_type(UserType.TA).iter()
         """
+
+        if type(user_type) is str:
+            user_type = UserType.from_str(user_type)
 
         items = {
             AllItems.HOME: ([], NavbarItem('home', reverse('index'), icon='house-door-fill')),

--- a/TAScheduler/viewsupport/navbar.py
+++ b/TAScheduler/viewsupport/navbar.py
@@ -52,16 +52,13 @@ class NavbarItem:
 class AllItems(Enum):
     """Represents exactly one of the possible menu items for an admin,
     intended to be used as an iterable"""
-    HOME =      [],                 NavbarItem('home', reverse('index'), icon='house-door-fill')
-    MAIL =      [],                 NavbarItem('inbox', reverse('index'), icon='mailbox')
-    USERS =     [],                 NavbarItem('user directory', reverse('users-directory'), icon='people-fill')
-    COURSES =   [],                 NavbarItem('courses', reverse('courses-directory'), icon='text-paragraph')
-    SECTIONS =  [],                 NavbarItem('course sections', reverse('sections-directory'), icon='kanban-fill')
-    LABS =      [],                 NavbarItem('labs', reverse('labs-directory'), icon='bar-chart-fill')
-    SKILLS =    [UserType.ADMIN],   NavbarItem('skills', reverse('skills-directory'), icon='award-fill')
-
-    def __init__(self):
-        self._for = None
+    HOME = 0
+    MAIL = 1
+    USERS = 2
+    COURSES = 3
+    SECTIONS = 4
+    LABS = 5
+    SKILLS = 6
 
     @classmethod
     def for_type(cls, user_type: UserType):
@@ -74,6 +71,16 @@ class AllItems(Enum):
         or
         AllItems.for_type(UserType.TA).iter()
         """
+
+        items = {
+            AllItems.HOME: ([], NavbarItem('home', reverse('index'), icon='house-door-fill')),
+            AllItems.MAIL: ([], NavbarItem('inbox', reverse('index'), icon='mailbox')),
+            AllItems.USERS: ([], NavbarItem('user directory', reverse('users-directory'), icon='people-fill')),
+            AllItems.COURSES: ([], NavbarItem('courses', reverse('courses-directory'), icon='text-paragraph')),
+            AllItems.SECTIONS: ([], NavbarItem('course sections', reverse('sections-directory'), icon='kanban-fill')),
+            AllItems.LABS: ([], NavbarItem('labs', reverse('labs-directory'), icon='bar-chart-fill')),
+            AllItems.SKILLS: ([UserType.ADMIN], NavbarItem('skills', reverse('index'), icon='award-fill')),
+        }
 
         class PartialIterator:
             """
@@ -89,12 +96,12 @@ class AllItems(Enum):
             @staticmethod
             def __map_disable__(maybe_disable: Optional[AllItems]) -> Callable[[AllItems], NavbarItem]:
                 if maybe_disable is None:
-                    return lambda a: a
+                    return lambda i: items[i][1]
                 else:
-                    def disable(item: AllItems) -> NavbarItem:
-                        if maybe_disable == item:
-                            item[1].disable()
-                        return item[1]
+                    def disable(i: AllItems) -> NavbarItem:
+                        if maybe_disable == items[i]:
+                            items[i][1].disable()
+                        return items[i][1]
 
                     return disable
 
@@ -110,7 +117,6 @@ class AllItems(Enum):
         # Return the partially applied iterator class defined above
         return PartialIterator(
             filter(
-                lambda a: a[0] is [] or user_type in a[0],
-                iter(cls),
+                lambda a: items[a][0] is [] or user_type in items[a][0],
             )
         )

--- a/TAScheduler/viewsupport/navbar.py
+++ b/TAScheduler/viewsupport/navbar.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
 from django.shortcuts import reverse
 from TAScheduler.viewsupport.icons import IconItem
-from typing import Union, Optional, Iterable
+from TAScheduler.models import UserType
+from typing import Union, Optional, Iterable, Callable
 from enum import Enum
 
 
@@ -47,47 +49,68 @@ class NavbarItem:
             return self.icon.classes()
 
 
-class AdminItems(Enum):
+class AllItems(Enum):
     """Represents exactly one of the possible menu items for an admin,
     intended to be used as an iterable"""
-    HOME = 0
-    USERS = 1
-    COURSES = 2
-    SECTIONS = 3
-    LABS = 4
-    SKILLS = 5
+    HOME =      [],                 NavbarItem('home', reverse('index'), icon='house-door-fill')
+    MAIL =      [],                 NavbarItem('inbox', reverse('index'), icon='mailbox')
+    USERS =     [],                 NavbarItem('user directory', reverse('users-directory'), icon='people-fill')
+    COURSES =   [],                 NavbarItem('courses', reverse('courses-directory'), icon='text-paragraph')
+    SECTIONS =  [],                 NavbarItem('course sections', reverse('sections-directory'), icon='kanban-fill')
+    LABS =      [],                 NavbarItem('labs', reverse('labs-directory'), icon='bar-chart-fill')
+    SKILLS =    [UserType.ADMIN],   NavbarItem('skills', reverse('skills-directory'), icon='award-fill')
 
-    def get_item(self):
-        if self == AdminItems.HOME:
-            return NavbarItem('home', reverse('index'), icon='house-door-fill')
-        elif self == AdminItems.USERS:
-            return NavbarItem('user directory', reverse('users-directory'), icon='people-fill')
-        elif self == AdminItems.COURSES:
-            return NavbarItem('courses', reverse('courses-directory'), icon='text-paragraph')
-        elif self == AdminItems.SECTIONS:
-            return NavbarItem('course sections', reverse('sections-directory'), icon='kanban-fill')
-        elif self == AdminItems.LABS:
-            return NavbarItem('labs', reverse('labs-directory'), icon='bar-chart-fill')
-        elif self == AdminItems.SKILLS:
-            return NavbarItem('skills', reverse('skills-directory'), icon='award-fill')
-
-    def map_disable(self):
-        """
-        returns a function to be used in map which will call get item for each
-        AdminItem passed in, but disable in the case that that item is self
-        """
-        return lambda a : a.get_item() if a != self else a.get_item().disable()
-
-    def items_iterable_except(self) -> Iterable[NavbarItem]:
-        """
-        Iterate over all AdminItems values, with the one equal to self disabled
-        """
-        return map(self.map_disable(), iter(AdminItems))
+    def __init__(self):
+        self._for = None
 
     @classmethod
-    def items_iterable(cls) -> Iterable[NavbarItem]:
+    def for_type(cls, user_type: UserType):
         """
-        Iterate over all AdminItems values, with none disabled.
-        """
-        return map(lambda a: a.get_item(), iter(cls))
+        Create a new (partially applied) iterator to get the list of navbar items.
 
+        can be used like:
+        AllItems.for_type(UserType.ADMIN).without(AllItems.MAIL).iter()
+
+        or
+        AllItems.for_type(UserType.TA).iter()
+        """
+
+        class PartialIterator:
+            """
+            Represents a list of nav items for the current user
+            has items which are not applicable to the current type removed
+            has the option to select a current page
+            """
+
+            def __init__(self, partial):
+                self._part = partial
+                self._except = None
+
+            @staticmethod
+            def __map_disable__(maybe_disable: Optional[AllItems]) -> Callable[[AllItems], NavbarItem]:
+                if maybe_disable is None:
+                    return lambda a: a
+                else:
+                    def disable(item: AllItems) -> NavbarItem:
+                        if maybe_disable == item:
+                            item[1].disable()
+                        return item[1]
+
+                    return disable
+
+            def without(self, item: AllItems) -> PartialIterator:
+                """Disable the page item that you are currently on"""
+                self._except = item
+                return self
+
+            def iter(self) -> Iterable[NavbarItem]:
+                """Return the final iterable of items for the user type"""
+                return map(PartialIterator.__map_disable__(self._except), self._part)
+
+        # Return the partially applied iterator class defined above
+        return PartialIterator(
+            filter(
+                lambda a: a[0] is [] or user_type in a[0],
+                iter(cls),
+            )
+        )

--- a/TAScheduler/viewsupport/navbar.py
+++ b/TAScheduler/viewsupport/navbar.py
@@ -77,12 +77,12 @@ class AllItems(Enum):
 
         items = {
             AllItems.HOME: ([], NavbarItem('home', reverse('index'), icon='house-door-fill')),
-            AllItems.MAIL: ([], NavbarItem('inbox', reverse('index'), icon='mailbox')),
+            AllItems.MAIL: ([], NavbarItem('inbox', reverse('index'), icon='mailbox')),  # TODO change me to final view name
             AllItems.USERS: ([], NavbarItem('user directory', reverse('users-directory'), icon='people-fill')),
             AllItems.COURSES: ([], NavbarItem('courses', reverse('courses-directory'), icon='text-paragraph')),
             AllItems.SECTIONS: ([], NavbarItem('course sections', reverse('sections-directory'), icon='kanban-fill')),
             AllItems.LABS: ([], NavbarItem('labs', reverse('labs-directory'), icon='bar-chart-fill')),
-            AllItems.SKILLS: ([UserType.ADMIN], NavbarItem('skills', reverse('index'), icon='award-fill')),
+            AllItems.SKILLS: ([UserType.ADMIN], NavbarItem('skills', reverse('skills-directory'), icon='award-fill')),
         }
 
         class PartialIterator:

--- a/TAScheduler/viewsupport/test_navbar.py
+++ b/TAScheduler/viewsupport/test_navbar.py
@@ -2,28 +2,6 @@ from django.test import TestCase
 from TAScheduler.viewsupport.navbar import *
 
 
-class TestAdminItemsEnum(TestCase):
-    def test_returns_correct_item(self):
-        item = AdminItems.HOME
-        navbar_item = item.get_item()
-        self.assertEqual(navbar_item.name, 'home', 'did not set correct home message')
-        self.assertEqual(navbar_item.enabled, True, 'did not default enabled correctly')
-        self.assertEqual(navbar_item.url, '/', 'did not default url to admin home')
-        self.assertEqual(navbar_item.icon.name, 'house-door-fill')
-
-    def test_map_disable(self):
-        map_fn = AdminItems.USERS.map_disable()
-
-        disabled = map_fn(AdminItems.USERS)
-        enabled = map_fn(AdminItems.HOME)
-
-        self.assertEqual(type(disabled), NavbarItem, 'did not return the correct type when disabling')
-        self.assertEqual(type(enabled), NavbarItem, 'did not return the correct type when leaving enabled')
-
-        self.assertEqual(disabled.get_enabled(), False, 'did not actually disable')
-        self.assertEqual(enabled.get_enabled(), True, 'did not leave others enabled')
-
-
 class TestNavbarItem(TestCase):
     def setUp(self):
         self.item_defaults = NavbarItem('home', '/home')


### PR DESCRIPTION
The navbar can now be initalized for any user using either of the following.

```python
AllItems
    .for_type(user.type)     # Filter out pages that aren't for the current user's type
    .without(AllItems.MAIL)  # Disable the current page
    .iter()                  # Make the result iterable

## == OR == ##

AllItems
    .for_type(user.type)     # Same as above, but we don't disable a page
    .iter()
```